### PR TITLE
0.4.3 pe_em/ElderofZion balans + ai fixy

### DIFF
--- a/scenarios/01_Bag-not_Under_Attack.cfg
+++ b/scenarios/01_Bag-not_Under_Attack.cfg
@@ -75,15 +75,8 @@
 		side = 2
 		controller=ai
 		recruit = Spearman, Bowman, Heavy Infantryman, Mage
-		{GOLD 0 40 60}
-		[ai]
-			village_value="0"
-			scout_village_targeting="0"
-			[avoid]
-				terrain="*^Vo"
-			[/avoid]
-		[/ai]
-		income = -6
+		{GOLD 50 75 100}
+		{INCOME 3 5 8}
 		village_gold=0
 		team_name = 2
 		user_team_name = _"Opponents"


### PR DESCRIPTION
zmiany golda 0-20-40 => 50-75-100 dla przeciwnika, income przeciwnika -6 => 3-5-8. Usunąłem cały tag [ai] bo powodował dziwne zachowania cavów. ~pe_em
